### PR TITLE
Implement Phase 1 foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@ This repository contains code and documentation for an AI-driven patient profili
 - The latest development plan is in [docs/project_plan_v3.md](docs/project_plan_v3.md).
 - Additional contributor instructions are provided in [AGENTS.md](AGENTS.md).
 - Phase 1 implementation guidance is documented in [docs/phase1_instructions.md](docs/phase1_instructions.md).
+
+## Setup
+
+1. Install Python 3.11 and create a virtual environment.
+2. Install required packages:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Set your OpenAI API key in the environment variable `OPENAI_API_KEY`.
+
+## Repository structure (Phase 1)
+
+- `prompts.py` – functions that call OpenAI to generate questions and feedback.
+- `data_persistence.py` – helper to save questionnaire data as CSV under `data/`.
+- `static/` – contains custom CSS (`style.css`) and favicon (`favicon.svg`).
+- `data/` – storage directory for interaction logs (created automatically).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,16 @@
+"""Streamlit entry point for Phase 1 demo."""
+import pathlib
+import streamlit as st
+
+STATIC_DIR = pathlib.Path(__file__).parent / "static"
+
+st.set_page_config(page_title="Patient Profiling", page_icon=str(STATIC_DIR / "favicon.svg"))
+
+# Load custom CSS
+css_path = STATIC_DIR / "style.css"
+if css_path.exists():
+    st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
+
+st.title("Patient Profiling System (Phase 1)")
+
+st.write("This is a placeholder UI. Functionality will be implemented in later phases.")

--- a/data_persistence.py
+++ b/data_persistence.py
@@ -1,0 +1,46 @@
+"""Utilities for saving interaction data to CSV."""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DATA_DIR.mkdir(exist_ok=True)
+CSV_PATH = DATA_DIR / "interactions.csv"
+
+
+COLUMNS = [
+    "timestamp",
+    "user_id",
+    "question_text",
+    "answer_text",
+    "total_question_count",
+    "evaluation_summary",
+]
+
+
+def save_interaction(
+    user_id: str,
+    question_text: str,
+    answer_text: str,
+    total_question_count: int,
+    evaluation_summary: str,
+) -> None:
+    """Append a single interaction row to the CSV file."""
+    new_file = not CSV_PATH.exists()
+    with CSV_PATH.open("a", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=COLUMNS)
+        if new_file:
+            writer.writeheader()
+        writer.writerow(
+            {
+                "timestamp": datetime.utcnow().isoformat(),
+                "user_id": user_id,
+                "question_text": question_text,
+                "answer_text": answer_text,
+                "total_question_count": total_question_count,
+                "evaluation_summary": evaluation_summary,
+            }
+        )

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,70 @@
+"""Prompt templates for the AI-driven patient profiling system."""
+from __future__ import annotations
+
+import os
+from typing import List
+import openai
+
+
+def _call_openai(messages: List[dict], temperature: float) -> str:
+    """Helper to call OpenAI chat completion."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY not set")
+    openai.api_key = api_key
+    response = openai.ChatCompletion.create(
+        model="gpt-4.1", messages=messages, temperature=temperature
+    )
+    return response.choices[0].message["content"].strip()
+
+
+def generate_question(axis: str, temperature: float = 0.4) -> str:
+    """Generate a single question for the given axis."""
+    system = (
+        "You are a medical survey designer. Use non-clinical wording to inquire about "
+        "patient personality traits. Format your reply as JSON with keys 'question_text' "
+        "and 'axis'."
+    )
+    user = (
+        "Generate one short question related to the following axis "
+        f"'{axis}'."
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    return _call_openai(messages, temperature)
+
+
+def feedback_for_patient(summary: str, temperature: float = 0.1) -> str:
+    """Generate patient-facing feedback based on answer summary."""
+    system = (
+        "You are an empathetic counselor. Provide reassuring feedback summarizing what "
+        "the patient values, avoiding mention of risk." 
+    )
+    user = (
+        "Based on the following summary of questionnaire answers, write concise "
+        "feedback titled '診療方針に関するご確認'.\n" + summary
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    return _call_openai(messages, temperature)
+
+
+def feedback_for_staff(summary: str, temperature: float = 0.1) -> str:
+    """Generate staff-facing feedback in structured JSON."""
+    system = (
+        "You are an experienced clinical psychologist and risk manager."
+    )
+    user = (
+        "Using the following score summary, produce analysis in JSON with keys "
+        "'risk_profile_summary', 'caution_points', 'recommended_actions', "
+        "'escalation_plan'.\n" + summary
+    )
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    return _call_openai(messages, temperature)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+openai

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">\n  <circle cx="32" cy="32" r="30" fill="#4A90E2"/>\n</svg>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,10 @@
+body {
+    background-color: #FFFFFF;
+    color: #4A4A4A;
+    font-family: 'Noto Sans JP', sans-serif;
+}
+
+.button-primary {
+    background-color: #4A90E2;
+    color: #FFFFFF;
+}


### PR DESCRIPTION
## Summary
- add package requirements
- add prompt functions for question generation and feedback
- add data saving utility
- create placeholder Streamlit app with custom CSS & favicon
- document setup instructions
- add valid placeholder favicon instead of empty file
- replace binary favicon with SVG

## Testing
- `python -m py_compile prompts.py data_persistence.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6850ddfc374483339f9c1c47164c76fe