### PR TITLE
フェーズ2の開発開始

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains code and documentation for an AI-driven patient profili
 - The latest development plan is in [docs/project_plan_v3.md](docs/project_plan_v3.md).
 - Additional contributor instructions are provided in [AGENTS.md](AGENTS.md).
 - Phase 1 implementation guidance is documented in [docs/phase1_instructions.md](docs/phase1_instructions.md).
+- Phase 2 introduces a basic questionnaire flow with scoring and radar chart visualization.
 
 ## Setup
 
@@ -16,9 +17,11 @@ This repository contains code and documentation for an AI-driven patient profili
    ```
 3. Set your OpenAI API key in the environment variable `OPENAI_API_KEY`.
 
-## Repository structure (Phase 1)
+## Repository structure (Phase 2)
 
+- `app.py` – Streamlit app implementing the questionnaire flow.
 - `prompts.py` – functions that call OpenAI to generate questions and feedback.
+- `questionnaire.py` – utilities to generate questions, score answers and create radar charts.
 - `data_persistence.py` – helper to save questionnaire data as CSV under `data/`.
 - `static/` – contains custom CSS (`style.css`) and favicon (`favicon.svg`).
 - `data/` – storage directory for interaction logs (created automatically).

--- a/app.py
+++ b/app.py
@@ -1,16 +1,81 @@
-"""Streamlit entry point for Phase 1 demo."""
+"""Streamlit application for questionnaire (Phase 2)."""
+import json
 import pathlib
+
 import streamlit as st
+
+import data_persistence
+import prompts
+import questionnaire
+
 
 STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
-st.set_page_config(page_title="Patient Profiling", page_icon=str(STATIC_DIR / "favicon.svg"))
+st.set_page_config(
+    page_title="Patient Profiling", page_icon=str(STATIC_DIR / "favicon.svg")
+)
 
 # Load custom CSS
 css_path = STATIC_DIR / "style.css"
 if css_path.exists():
     st.markdown(f"<style>{css_path.read_text()}</style>", unsafe_allow_html=True)
 
-st.title("Patient Profiling System (Phase 1)")
 
-st.write("This is a placeholder UI. Functionality will be implemented in later phases.")
+def init_state() -> None:
+    if "questions" not in st.session_state:
+        st.session_state.questions = questionnaire.generate_questionnaire()
+    if "answers" not in st.session_state:
+        st.session_state.answers = []
+    if "index" not in st.session_state:
+        st.session_state.index = 0
+
+
+def save_results(scores: dict) -> None:
+    summary = prompts.evaluation_summary(scores)
+    for i, q in enumerate(st.session_state.questions):
+        ans = st.session_state.answers[i]
+        data_persistence.save_interaction(
+            user_id="demo_user",
+            question_text=q["question_text"],
+            answer_text=str(ans["score"]),
+            total_question_count=len(st.session_state.questions),
+            evaluation_summary=summary,
+        )
+
+
+def show_results(scores: dict) -> None:
+    st.subheader("結果")
+    fig = questionnaire.radar_chart(scores)
+    st.plotly_chart(fig, use_container_width=True)
+    st.write("### 患者向けフィードバック")
+    st.write(prompts.feedback_for_patient(json.dumps(scores)))
+    st.write("### 医療従事者向けフィードバック")
+    st.json(json.loads(prompts.feedback_for_staff(json.dumps(scores))))
+
+
+def questionnaire_flow() -> None:
+    if st.session_state.index >= len(st.session_state.questions):
+        scores = questionnaire.score_answers(st.session_state.answers)
+        save_results(scores)
+        show_results(scores)
+        return
+
+    q = st.session_state.questions[st.session_state.index]
+    st.write(f"**{q['question_text']}**")
+    choice = st.radio(
+        "回答を選択してください", [1, 2, 3, 4, 5], key=f"q{st.session_state.index}"
+    )
+    if st.button("次へ"):
+        st.session_state.answers.append({"axis": q["axis"], "score": choice})
+        st.session_state.index += 1
+        st.experimental_rerun()
+
+
+def main() -> None:
+    st.title("Patient Profiling System")
+    init_state()
+    questionnaire_flow()
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts.py
+++ b/prompts.py
@@ -68,3 +68,14 @@ def feedback_for_staff(summary: str, temperature: float = 0.1) -> str:
         {"role": "user", "content": user},
     ]
     return _call_openai(messages, temperature)
+
+
+def evaluation_summary(scores: dict, temperature: float = 0.1) -> str:
+    """Summarize score rationale in ~200 characters."""
+    system = "You summarize patient questionnaire results in around 200 Japanese characters."
+    user = "Summarize the following scores: " + str(scores)
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    return _call_openai(messages, temperature)

--- a/questionnaire.py
+++ b/questionnaire.py
@@ -1,0 +1,63 @@
+"""Utilities for generating and scoring the questionnaire."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+import plotly.graph_objects as go
+
+import prompts
+
+AXES = [
+    "特権意識と期待",
+    "情動の不安定性",
+    "不信感と猜疑心",
+    "依存性と操作性",
+    "統制欲求と完璧主義",
+]
+
+
+def generate_questionnaire(num_questions_per_axis: int = 5) -> List[dict]:
+    """Generate a list of questions covering all axes."""
+    questions: List[dict] = []
+    for axis in AXES:
+        for i in range(num_questions_per_axis):
+            temp = 0.4 + 0.02 * i
+            q_json = prompts.generate_question(axis, temperature=temp)
+            try:
+                q = json.loads(q_json)
+            except json.JSONDecodeError:
+                q = {"question_text": q_json, "axis": axis}
+            questions.append(q)
+    return questions
+
+
+def score_answers(responses: List[dict]) -> Dict[str, float]:
+    """Return average score per axis from a list of responses."""
+    scores: Dict[str, List[int]] = {axis: [] for axis in AXES}
+    for r in responses:
+        axis = r["axis"]
+        score = int(r["score"])
+        if axis in scores:
+            scores[axis].append(score)
+    averages: Dict[str, float] = {}
+    for axis, vals in scores.items():
+        if vals:
+            averages[axis] = sum(vals) / len(vals)
+        else:
+            averages[axis] = 0.0
+    return averages
+
+
+def radar_chart(scores: Dict[str, float]) -> go.Figure:
+    """Create a radar chart from axis scores."""
+    categories = list(scores.keys())
+    values = list(scores.values())
+    values.append(values[0])
+    categories.append(categories[0])
+    fig = go.Figure(
+        data=[go.Scatterpolar(r=values, theta=categories, fill="toself")]
+    )
+    fig.update_layout(polar=dict(radialaxis=dict(range=[1, 5])), showlegend=False)
+    return fig


### PR DESCRIPTION
## Summary
- implement questionnaire flow with Streamlit
- add utilities for question generation, scoring and radar chart
- support evaluation summaries
- update README for Phase 2

## Testing
- `python -m py_compile app.py prompts.py questionnaire.py data_persistence.py`
- `pip install -r requirements.txt`
- `streamlit --version`


------
https://chatgpt.com/codex/tasks/task_e_6850eab1864c8333adc76f9af6bb738d