### PR TITLE
Implement phase 3 UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository contains code and documentation for an AI-driven patient profili
 - The latest development plan is in [docs/project_plan_v3.md](docs/project_plan_v3.md).
 - Additional contributor instructions are provided in [AGENTS.md](AGENTS.md).
 - Phase 1 implementation guidance is documented in [docs/phase1_instructions.md](docs/phase1_instructions.md).
-- Phase 2 introduces a basic questionnaire flow with scoring and radar chart visualization.
+- Phase 2 introduced a basic questionnaire flow with scoring and radar chart visualization.
+- Phase 3 adds a UI mode selector allowing patients to answer the questionnaire and staff to review stored results.
 
 ## Setup
 
@@ -17,9 +18,9 @@ This repository contains code and documentation for an AI-driven patient profili
    ```
 3. Set your OpenAI API key in the environment variable `OPENAI_API_KEY`.
 
-## Repository structure (Phase 2)
+## Repository structure
 
-- `app.py` – Streamlit app implementing the questionnaire flow.
+- `app.py` – Streamlit app with patient and staff modes.
 - `prompts.py` – functions that call OpenAI to generate questions and feedback.
 - `questionnaire.py` – utilities to generate questions, score answers and create radar charts.
 - `data_persistence.py` – helper to save questionnaire data as CSV under `data/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit
 pandas
 openai
+plotly


### PR DESCRIPTION
## Summary
- integrate project plan tasks for phase 3
- add patient and staff modes to the Streamlit app
- extend README with phase 3 notes
- include Plotly dependency in requirements

## Testing
- `python -m py_compile app.py data_persistence.py prompts.py questionnaire.py`


------
https://chatgpt.com/codex/tasks/task_e_6850edb51f6883338977730d06a2585b