### PR TITLE
Enhance user onboarding with ID recall

### DIFF
--- a/data_persistence.py
+++ b/data_persistence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 DATA_DIR = Path(__file__).resolve().parent / "data"
 DATA_DIR.mkdir(exist_ok=True)
 CSV_PATH = DATA_DIR / "interactions.csv"
+USERS_PATH = DATA_DIR / "users.csv"
 
 
 COLUMNS = [
@@ -20,6 +21,8 @@ COLUMNS = [
     "evaluation_summary",
 ]
 
+USER_COLUMNS = ["user_id", "user_name"]
+
 
 def save_interaction(
     user_id: str,
@@ -27,8 +30,10 @@ def save_interaction(
     answer_text: str,
     total_question_count: int,
     evaluation_summary: str,
+    start_timestamp: str | None = None,
 ) -> None:
     """Append a single interaction row to the CSV file."""
+    ts = start_timestamp or datetime.now(timezone.utc).isoformat()
     new_file = not CSV_PATH.exists()
     with CSV_PATH.open("a", newline="", encoding="utf-8") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=COLUMNS)
@@ -36,7 +41,7 @@ def save_interaction(
             writer.writeheader()
         writer.writerow(
             {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": ts,
                 "user_id": user_id,
                 "question_text": question_text,
                 "answer_text": answer_text,
@@ -44,3 +49,31 @@ def save_interaction(
                 "evaluation_summary": evaluation_summary,
             }
         )
+
+
+def save_user(user_id: str, user_name: str) -> None:
+    """Persist user ID and name mapping if not already stored."""
+    new_file = not USERS_PATH.exists()
+    users: dict[str, str] = {}
+    if USERS_PATH.exists():
+        with USERS_PATH.open(newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                users[row["user_id"]] = row["user_name"]
+    if user_id in users:
+        return
+    with USERS_PATH.open("a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=USER_COLUMNS)
+        if new_file:
+            writer.writeheader()
+        writer.writerow({"user_id": user_id, "user_name": user_name})
+
+
+def get_user_name(user_id: str) -> str | None:
+    """Return stored user name for ID if available."""
+    if not USERS_PATH.exists():
+        return None
+    with USERS_PATH.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            if row["user_id"] == user_id:
+                return row["user_name"]
+    return None

--- a/prompts.py
+++ b/prompts.py
@@ -24,9 +24,9 @@ def _call_openai(messages: List[dict], temperature: float) -> str:
 def generate_question(axis: str, temperature: float = 0.4) -> str:
     """Generate a single question for the given axis."""
     system = (
-        "You are a medical survey designer. Use non-clinical wording to inquire about "
-        "patient personality traits. Format your reply as JSON with keys 'question_text' "
-        "and 'axis'."
+        "You are a medical survey designer. Use non-clinical wording in Japanese to "
+        "inquire about patient personality traits. The question must be short and the "
+        "reply should be formatted as JSON with keys 'question_text' and 'axis'."
     )
     user = (
         "Generate one short question related to the following axis "

--- a/tests/test_data_persistence.py
+++ b/tests/test_data_persistence.py
@@ -10,11 +10,26 @@ import data_persistence
 def test_save_interaction(tmp_path, monkeypatch):
     path = tmp_path / "test.csv"
     monkeypatch.setattr(data_persistence, "CSV_PATH", path)
+    monkeypatch.setattr(data_persistence, "USERS_PATH", tmp_path / "users.csv")
+    ts = "2024-01-01T00:00:00+00:00"
     data_persistence.save_interaction(
         user_id="u", question_text="q", answer_text="a",
-        total_question_count=1, evaluation_summary="s"
+        total_question_count=1, evaluation_summary="s", start_timestamp=ts
     )
     assert path.exists()
     rows = list(csv.DictReader(path.open()))
     assert rows[0]["user_id"] == "u"
     assert rows[0]["evaluation_summary"] == "s"
+    assert rows[0]["timestamp"] == ts
+
+
+def test_save_and_get_user(tmp_path, monkeypatch):
+    users = tmp_path / "users.csv"
+    monkeypatch.setattr(data_persistence, "USERS_PATH", users)
+    data_persistence.save_user("abc", "Taro")
+    assert users.exists()
+    assert data_persistence.get_user_name("abc") == "Taro"
+    # Saving again should not duplicate
+    data_persistence.save_user("abc", "Taro")
+    rows = list(csv.DictReader(users.open()))
+    assert len(rows) == 1


### PR DESCRIPTION
## Summary
- store user ID/name pairs and reuse saved names
- initialize questionnaire with stored name if ID exists
- test user info persistence alongside interaction logging

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685108a4e0bc8333842ca2d78a305491