### PR TITLE
Fix rerun api

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains code and documentation for an AI-driven patient profili
 ## Setup
 
 1. Install Python 3.11 and create a virtual environment.
-2. Install required packages:
+2. Install required packages (the app expects Streamlit version 1.25 or later):
 
    ```bash
    pip install -r requirements.txt

--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ def show_start_page() -> None:
         st.session_state.user_id = user_id
         st.session_state.start_time = datetime.now(timezone.utc).isoformat()
         st.session_state.started = True
-        st.experimental_rerun()
+        st.rerun()
 
 
 def save_results(scores: dict) -> None:
@@ -112,7 +112,7 @@ def questionnaire_flow() -> None:
     if st.button("次へ"):
         st.session_state.answers.append({"axis": q["axis"], "score": choice})
         st.session_state.index += 1
-        st.experimental_rerun()
+        st.rerun()
 
 
 def staff_dashboard() -> None:


### PR DESCRIPTION
## Summary
- use `st.rerun` instead of the deprecated `st.experimental_rerun`
- note the Streamlit minimum version requirement in setup docs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510fba12c48333850bf122c9d1eebb