### PR TITLE
Improve scale guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,19 @@ This repository contains code and documentation for an AI-driven patient profili
 
    Windows users can run `run_app.bat` for convenience:
 
-   ```bat
-   run_app.bat
-   ```
+  ```bat
+  run_app.bat
+  ```
+
+## Answer scale
+
+Questions are answered on a five-point Likert scale. The options correspond to:
+
+1. **全くそう思わない** (strongly disagree)
+2. **あまりそう思わない** (disagree)
+3. **どちらとも言えない** (neutral)
+4. **そう思う** (agree)
+5. **とてもそう思う** (strongly agree)
 
 ## Repository structure
 

--- a/app.py
+++ b/app.py
@@ -106,8 +106,18 @@ def questionnaire_flow() -> None:
 
     q = st.session_state.questions[st.session_state.index]
     st.write(f"**{q['question_text']}**")
+    scale_labels = {
+        1: "1 全くそう思わない",
+        2: "2 あまりそう思わない",
+        3: "3 どちらとも言えない",
+        4: "4 そう思う",
+        5: "5 とてもそう思う",
+    }
     choice = st.radio(
-        "回答を選択してください", [1, 2, 3, 4, 5], key=f"q{st.session_state.index}"
+        "回答を選択してください",
+        [1, 2, 3, 4, 5],
+        format_func=lambda x: scale_labels[x],
+        key=f"q{st.session_state.index}",
     )
     if st.button("次へ"):
         st.session_state.answers.append({"axis": q["axis"], "score": choice})


### PR DESCRIPTION
## Summary
- display labels for the Likert scale options
- describe the five-point scale in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685114a925c483339b8b71907dea612b